### PR TITLE
chore: override tailwind default list styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -16,4 +16,12 @@ body {
   :root {
     --radius: 0.5rem;
   }
+  ul {
+    @apply list-disc;
+    @apply my-4 pl-10;
+  }
+  ol {
+    @apply list-decimal;
+    @apply my-4 pl-10;
+  }
 }


### PR DESCRIPTION
https://tailwindcss.com/docs/preflight#lists-are-unstyled

by default tailwind removes styles of ul and ol, this PR sets the style for lists.

used default CSS classes for this elements https://www.w3schools.com/cssref/css_default_values.php