### PR TITLE
fix: retrofunding improvements for pool details

### DIFF
--- a/src/components/IconLabel/IconLabel.tsx
+++ b/src/components/IconLabel/IconLabel.tsx
@@ -74,7 +74,7 @@ export const IconLabel: React.FC<
     ))
     .with(
       { type: "roundPeriod" },
-      ({ startDate, endDate = undefined, className, isLoading, label }) => (
+      ({ startDate, endDate = undefined, className, isLoading, label = "Review Period" }) => (
         <IconLabelContainer
           type="period"
           className={className}

--- a/src/components/IconLabel/IconLabel.tsx
+++ b/src/components/IconLabel/IconLabel.tsx
@@ -72,32 +72,35 @@ export const IconLabel: React.FC<
           ))}
       </IconLabelContainer>
     ))
-    .with({ type: "roundPeriod" }, ({ startDate, endDate = undefined, className, isLoading }) => (
-      <IconLabelContainer
-        type="period"
-        className={className}
-        iconType={IconType.CLOCK}
-        iconVariant={icon({ type: isLoading ? "loading" : "roundPeriod" })}
-      >
-        {match(isLoading)
-          .with(true, () => (
-            <div className="flex items-center gap-1">
-              <span className={text({ type: "roundPeriod" })}>{`Review period:`}</span>
-              <Skeleton className="h-6 w-72 rounded-lg" />
-            </div>
-          ))
-          .otherwise(() => (
-            <span className={text({ type: "roundPeriod" })}>{`Review period: ${formatDate(
-              startDate,
-              DateFormat.ShortMonthDayYear24HourUTC,
-            )} - ${
-              endDate
-                ? formatDate(endDate, DateFormat.ShortMonthDayYear24HourUTC)
-                : "No end date (open round)"
-            }`}</span>
-          ))}
-      </IconLabelContainer>
-    ))
+    .with(
+      { type: "roundPeriod" },
+      ({ startDate, endDate = undefined, className, isLoading, label }) => (
+        <IconLabelContainer
+          type="period"
+          className={className}
+          iconType={IconType.CLOCK}
+          iconVariant={icon({ type: isLoading ? "loading" : "roundPeriod" })}
+        >
+          {match(isLoading)
+            .with(true, () => (
+              <div className="flex items-center gap-1">
+                <span className={text({ type: "roundPeriod" })}>{label}</span>
+                <Skeleton className="h-6 w-72 rounded-lg" />
+              </div>
+            ))
+            .otherwise(() => (
+              <span className={text({ type: "roundPeriod" })}>{`${label}: ${formatDate(
+                startDate,
+                DateFormat.ShortMonthDayYear24HourUTC,
+              )} - ${
+                endDate
+                  ? formatDate(endDate, DateFormat.ShortMonthDayYear24HourUTC)
+                  : "No end date (open round)"
+              }`}</span>
+            ))}
+        </IconLabelContainer>
+      ),
+    )
     .with({ type: "dateWithPrefix" }, ({ date, prefix, className, isLoading }) => (
       <IconLabelContainer
         type="date"

--- a/src/components/IconLabel/types.ts
+++ b/src/components/IconLabel/types.ts
@@ -21,6 +21,7 @@ interface PeriodProps {
 
 interface RoundPeriodProps {
   type: "roundPeriod";
+  label: string;
   startDate: Date;
   endDate?: Date;
   className?: string;

--- a/src/components/IconLabel/types.ts
+++ b/src/components/IconLabel/types.ts
@@ -21,9 +21,9 @@ interface PeriodProps {
 
 interface RoundPeriodProps {
   type: "roundPeriod";
-  label: string;
   startDate: Date;
   endDate?: Date;
+  label?: string;
   className?: string;
 }
 

--- a/src/features/checker/apps/Checker.stories.tsx
+++ b/src/features/checker/apps/Checker.stories.tsx
@@ -46,3 +46,32 @@ export const Default: Story = {
     );
   },
 };
+
+export const Embedded: Story = {
+  render(args) {
+    // New StoryWrapper component
+    const StoryWrapper = () => {
+      const { setEvaluationBody, isSuccess, isEvaluating, isError } = usePerformEvaluation();
+      const { steps, setReviewBody, isReviewing } = usePerformOnChainReview();
+
+      return (
+        <Checker
+          {...args}
+          setEvaluationBody={setEvaluationBody}
+          isSuccess={isSuccess}
+          isEvaluating={isEvaluating}
+          isError={isError}
+          steps={steps}
+          setReviewBody={setReviewBody}
+          isReviewing={isReviewing}
+          isStandalone={false}
+        />
+      );
+    };
+    return (
+      <CheckerProvider>
+        <StoryWrapper />
+      </CheckerProvider>
+    );
+  },
+};

--- a/src/features/checker/apps/Checker.tsx
+++ b/src/features/checker/apps/Checker.tsx
@@ -19,6 +19,7 @@ export interface CheckerProps {
   steps: Step[];
   setReviewBody: (reviewBody: ReviewBody | null) => void;
   isReviewing: boolean;
+  isStandalone: boolean;
 }
 
 export const Checker = (props: CheckerProps) => {

--- a/src/features/checker/pages/ApplicationEvaluationOverviewPage/ApplicationEvaluationOverviewPage.tsx
+++ b/src/features/checker/pages/ApplicationEvaluationOverviewPage/ApplicationEvaluationOverviewPage.tsx
@@ -20,6 +20,7 @@ export interface ApplicationEvaluationOverviewPageProps {
   poolId: string;
   applicationId: string;
   address: Hex;
+  isStandalone: boolean;
 }
 
 export const ApplicationEvaluationOverviewPage = ({
@@ -27,6 +28,7 @@ export const ApplicationEvaluationOverviewPage = ({
   poolId,
   applicationId,
   address,
+  isStandalone,
 }: ApplicationEvaluationOverviewPageProps) => {
   useInitialize({ address, poolId, chainId });
 
@@ -49,17 +51,19 @@ export const ApplicationEvaluationOverviewPage = ({
 
   return (
     <div className="flex flex-col gap-6">
-      <PoolSummary
-        chainId={chainId}
-        poolId={poolId}
-        programId={poolData?.project.id as string}
-        strategyName={poolData?.strategyName}
-        name={poolData?.roundMetadata.name}
-        applicationsStartTime={poolData?.applicationsStartTime}
-        applicationsEndTime={poolData?.applicationsEndTime}
-        donationsStartTime={poolData?.donationsStartTime}
-        donationsEndTime={poolData?.donationsEndTime}
-      />
+      {isStandalone && (
+        <PoolSummary
+          chainId={chainId}
+          poolId={poolId}
+          programId={poolData?.project.id as string}
+          strategyName={poolData?.strategyName}
+          name={poolData?.roundMetadata.name}
+          applicationsStartTime={poolData?.applicationsStartTime}
+          applicationsEndTime={poolData?.applicationsEndTime}
+          donationsStartTime={poolData?.donationsStartTime}
+          donationsEndTime={poolData?.donationsEndTime}
+        />
+      )}
       <div className="mx-auto flex max-w-[1440px] flex-col gap-4 px-20">
         <div>
           <Button

--- a/src/features/checker/pages/ReviewApplicationsPage/ReviewApplicationsPage.tsx
+++ b/src/features/checker/pages/ReviewApplicationsPage/ReviewApplicationsPage.tsx
@@ -18,7 +18,7 @@ import {
 import { getManagerUrl } from "~checker/utils";
 import { PoolSummary } from "~pool";
 
-export const ReviewApplicationsPage = () => {
+export const ReviewApplicationsPage = ({ isStandalone }: { isStandalone: boolean }) => {
   const { categorizedReviews, statCardsProps, poolData, poolFetchState } =
     useGetApplicationsReviewPage() || {};
   const { poolId, chainId } = useCheckerContext();
@@ -63,27 +63,31 @@ export const ReviewApplicationsPage = () => {
 
   return (
     <div className="flex flex-col gap-6 ">
-      <PoolSummary
-        isLoading={isLoading}
-        chainId={chainId}
-        poolId={poolId}
-        programId={poolData?.project.id as string}
-        strategyName={poolData?.strategyName}
-        name={poolData?.roundMetadata?.name}
-        applicationsStartTime={poolData?.applicationsStartTime}
-        applicationsEndTime={poolData?.applicationsEndTime}
-        donationsStartTime={poolData?.donationsStartTime}
-        donationsEndTime={poolData?.donationsEndTime}
-      />
+      {isStandalone && (
+        <PoolSummary
+          isLoading={isLoading}
+          chainId={chainId}
+          poolId={poolId}
+          programId={poolData?.project.id as string}
+          strategyName={poolData?.strategyName}
+          name={poolData?.roundMetadata?.name}
+          applicationsStartTime={poolData?.applicationsStartTime}
+          applicationsEndTime={poolData?.applicationsEndTime}
+          donationsStartTime={poolData?.donationsStartTime}
+          donationsEndTime={poolData?.donationsEndTime}
+        />
+      )}
       <div className="mx-auto flex max-w-[1440px] flex-col gap-6 px-20">
-        <div className="flex justify-start">
-          <Button
-            variant="secondry"
-            icon={<Icon type={IconType.CHEVRON_LEFT} />}
-            onClick={openRoundInManager}
-            value="back to round manager"
-          />
-        </div>
+        {isStandalone && (
+          <div className="flex justify-start">
+            <Button
+              variant="secondry"
+              icon={<Icon type={IconType.CHEVRON_LEFT} />}
+              onClick={openRoundInManager}
+              value="back to round manager"
+            />
+          </div>
+        )}
         <StatCardGroup stats={statCardsProps as StatCardProps[]} justify="center" />
         <div className="flex flex-col gap-8">
           <div className="flex flex-col gap-4">

--- a/src/features/checker/pages/ReviewApplicationsPage/ReviewApplicationsPage.tsx
+++ b/src/features/checker/pages/ReviewApplicationsPage/ReviewApplicationsPage.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/primitives/Button";
 import { Icon, IconType } from "@/primitives/Icon";
 import { StatCardProps } from "@/primitives/StatCard";
 import { StatCardGroup } from "@/primitives/StatCardGroup";
+import { PoolType } from "@/types";
 
 import { ApplicationsSection } from "~checker/components";
 import { useGetApplicationsReviewPage } from "~checker/hooks";
@@ -15,7 +16,7 @@ import {
   useCheckerContext,
   useCheckerDispatchContext,
 } from "~checker/store";
-import { getManagerUrl } from "~checker/utils";
+import { getManagerUrl, getRoundLinkOnManager } from "~checker/utils";
 import { PoolSummary } from "~pool";
 
 export const ReviewApplicationsPage = ({ isStandalone }: { isStandalone: boolean }) => {
@@ -51,7 +52,10 @@ export const ReviewApplicationsPage = ({ isStandalone }: { isStandalone: boolean
   };
 
   const openRoundInManager = () => {
-    window.open(`${getManagerUrl(chainId)}/#/chain/${chainId}/round/${poolId}`, "_blank");
+    window.open(
+      getRoundLinkOnManager(chainId, poolId, poolData?.strategyName as PoolType),
+      "_blank",
+    );
   };
 
   const openCheckerApplicationEvaluations = (projectId: string) => {

--- a/src/features/checker/pages/SubmitApplicationEvaluationPage/SubmitApplicationEvaluationPage.stories.tsx
+++ b/src/features/checker/pages/SubmitApplicationEvaluationPage/SubmitApplicationEvaluationPage.stories.tsx
@@ -60,6 +60,7 @@ export const Default: Story = {
         chainId={args.chainId}
         poolId={args.poolId}
         address={args.address}
+        isStandalone={true}
       />
     );
   },

--- a/src/features/checker/pages/SubmitApplicationEvaluationPage/SubmitApplicationEvaluationPage.tsx
+++ b/src/features/checker/pages/SubmitApplicationEvaluationPage/SubmitApplicationEvaluationPage.tsx
@@ -33,6 +33,7 @@ export interface SubmitApplicationEvaluationPageProps {
   isSuccess: boolean;
   isEvaluating: boolean;
   isError: boolean;
+  isStandalone: boolean;
 }
 
 export const SubmitApplicationEvaluationPage = ({
@@ -44,6 +45,7 @@ export const SubmitApplicationEvaluationPage = ({
   isSuccess,
   isEvaluating,
   isError,
+  isStandalone,
 }: SubmitApplicationEvaluationPageProps) => {
   useInitialize({ address, poolId, chainId });
 
@@ -134,17 +136,19 @@ export const SubmitApplicationEvaluationPage = ({
 
   return (
     <div className="flex flex-col gap-6">
-      <PoolSummary
-        chainId={chainId}
-        poolId={poolId}
-        programId={poolData?.project.id as string}
-        strategyName={poolData?.strategyName}
-        name={poolData?.roundMetadata?.name}
-        applicationsStartTime={poolData?.applicationsStartTime}
-        applicationsEndTime={poolData?.applicationsEndTime}
-        donationsStartTime={poolData?.donationsStartTime}
-        donationsEndTime={poolData?.donationsEndTime}
-      />
+      {isStandalone && (
+        <PoolSummary
+          chainId={chainId}
+          poolId={poolId}
+          programId={poolData?.project.id as string}
+          strategyName={poolData?.strategyName}
+          name={poolData?.roundMetadata?.name}
+          applicationsStartTime={poolData?.applicationsStartTime}
+          applicationsEndTime={poolData?.applicationsEndTime}
+          donationsStartTime={poolData?.donationsStartTime}
+          donationsEndTime={poolData?.donationsEndTime}
+        />
+      )}
       <div className="mx-auto flex max-w-[1440px] flex-col gap-4 px-20">
         <SubmitApplicationEvaluationModal
           evaluationStatus={evaluationStatus}

--- a/src/features/checker/pages/SubmitFinalEvaluationPage/SubmitFinalEvaluationPage.tsx
+++ b/src/features/checker/pages/SubmitFinalEvaluationPage/SubmitFinalEvaluationPage.tsx
@@ -28,12 +28,14 @@ export interface SubmitFinalEvaluationPageProps {
   steps: Step[];
   setReviewBody: (reviewBody: ReviewBody | null) => void;
   isReviewing: boolean;
+  isStandalone: boolean;
 }
 
 export const SubmitFinalEvaluationPage = ({
   steps,
   setReviewBody,
   isReviewing,
+  isStandalone,
 }: SubmitFinalEvaluationPageProps) => {
   const { categorizedReviews, statCardsProps, reviewBody, poolData } =
     useGetApplicationsFinalEvaluationPage() || {};
@@ -115,17 +117,19 @@ export const SubmitFinalEvaluationPage = ({
 
   return (
     <div className="flex flex-col gap-6">
-      <PoolSummary
-        chainId={chainId as number}
-        poolId={poolId as string}
-        programId={poolData?.project.id as string}
-        strategyName={poolData?.strategyName}
-        name={poolData?.roundMetadata.name}
-        applicationsStartTime={poolData?.applicationsStartTime}
-        applicationsEndTime={poolData?.applicationsEndTime}
-        donationsStartTime={poolData?.donationsStartTime}
-        donationsEndTime={poolData?.donationsEndTime}
-      />
+      {isStandalone && (
+        <PoolSummary
+          chainId={chainId as number}
+          poolId={poolId as string}
+          programId={poolData?.project.id as string}
+          strategyName={poolData?.strategyName}
+          name={poolData?.roundMetadata.name}
+          applicationsStartTime={poolData?.applicationsStartTime}
+          applicationsEndTime={poolData?.applicationsEndTime}
+          donationsStartTime={poolData?.donationsStartTime}
+          donationsEndTime={poolData?.donationsEndTime}
+        />
+      )}
       <div className="mx-auto flex max-w-[1440px] flex-col  gap-6 px-20">
         <div className="flex justify-start">
           <Button

--- a/src/features/checker/pages/SubmitFinalEvaluationPage/SubmitFinalEvaluationPage.tsx
+++ b/src/features/checker/pages/SubmitFinalEvaluationPage/SubmitFinalEvaluationPage.tsx
@@ -9,7 +9,7 @@ import { useToast } from "@/hooks/useToast";
 import { Button } from "@/primitives/Button";
 import { Icon, IconType } from "@/primitives/Icon";
 import { StatCardGroup } from "@/primitives/StatCardGroup";
-import { Step } from "@/types";
+import { PoolType, Step } from "@/types";
 
 import { ProjectEvaluationList } from "~checker/components";
 import { useGetApplicationsFinalEvaluationPage } from "~checker/hooks";
@@ -19,7 +19,7 @@ import {
   useCheckerContext,
 } from "~checker/store";
 import { EvaluationAction, ReviewBody } from "~checker/types";
-import { getManagerUrl } from "~checker/utils";
+import { getManagerUrl, getRoundLinkOnManager } from "~checker/utils";
 import { PoolSummary } from "~pool";
 
 import { SubmitFinalEvaluationModal } from "./SubmitFinalEvaluationModal";
@@ -136,7 +136,13 @@ export const SubmitFinalEvaluationPage = ({
             variant="secondry"
             icon={<Icon type={IconType.CHEVRON_LEFT} />}
             onClick={() =>
-              window.open(`${getManagerUrl(chainId as number)}/#/chain/${chainId}/round/${poolId}`)
+              window.open(
+                getRoundLinkOnManager(
+                  chainId as number,
+                  poolId as string,
+                  poolData?.strategyName as PoolType,
+                ),
+              )
             }
             value="back to round manager"
           />

--- a/src/features/checker/pages/ViewApplicationEvaluationsPage/ViewApplicationEvaluationsPage.tsx
+++ b/src/features/checker/pages/ViewApplicationEvaluationsPage/ViewApplicationEvaluationsPage.tsx
@@ -11,7 +11,7 @@ import { Icon, IconType } from "@/primitives/Icon";
 import { ApplicationSummary, SummaryAccordians } from "~application";
 import { ReviewDropdownList } from "~checker/components";
 import { useApplicationEvaluations, useGetPastApplications } from "~checker/hooks";
-import { getExplorerUrl } from "~checker/utils";
+import { getApplicationLinkOnExplorer, getExplorerUrl } from "~checker/utils";
 import { ProjectBanner } from "~project";
 import { ProjectSummary } from "~project";
 
@@ -80,10 +80,7 @@ export const ViewApplicationEvaluationsPage: React.FC<ViewApplicationEvaluations
               variant="none"
               className="h-[38px] w-40 bg-white"
               onClick={() => {
-                window.open(
-                  `${getExplorerUrl(chainId)}/#/round/${chainId}/${poolId}/${applicationId}`,
-                  "_blank",
-                );
+                window.open(getApplicationLinkOnExplorer(chainId, poolId, applicationId), "_blank");
               }}
             />
           </div>

--- a/src/features/checker/routers/CheckerRouter.tsx
+++ b/src/features/checker/routers/CheckerRouter.tsx
@@ -29,6 +29,7 @@ export interface CheckerRouterProps {
   steps: Step[];
   setReviewBody: (reviewBody: ReviewBody | null) => void;
   isReviewing: boolean;
+  isStandalone: boolean;
 }
 
 export const CheckerRouter = ({
@@ -42,6 +43,7 @@ export const CheckerRouter = ({
   steps,
   setReviewBody,
   isReviewing,
+  isStandalone = true,
 }: CheckerRouterProps) => {
   useInitialize({ address, poolId, chainId });
 
@@ -53,7 +55,9 @@ export const CheckerRouter = ({
   }, [route]);
 
   return match(route)
-    .with({ id: CheckerRoute.ReviewApplications }, () => <ReviewApplicationsPage />)
+    .with({ id: CheckerRoute.ReviewApplications }, () => (
+      <ReviewApplicationsPage isStandalone={isStandalone} />
+    ))
     .with(
       { id: CheckerRoute.ApplicationEvaluationOverview, projectId: P.string.minLength(1) },
       ({ projectId }) => (
@@ -62,6 +66,7 @@ export const CheckerRouter = ({
           poolId={poolId}
           applicationId={projectId}
           address={address}
+          isStandalone={isStandalone}
         />
       ),
     )
@@ -78,6 +83,7 @@ export const CheckerRouter = ({
             chainId={chainId}
             poolId={poolId}
             address={address}
+            isStandalone={isStandalone}
           />
         );
       },
@@ -87,6 +93,7 @@ export const CheckerRouter = ({
         steps={steps}
         setReviewBody={setReviewBody}
         isReviewing={isReviewing}
+        isStandalone={isStandalone}
       />
     ))
     .otherwise(() => <div>{`Route Not Found: ${JSON.stringify(route)}`}</div>);

--- a/src/features/checker/utils/getGitcoinLinks.ts
+++ b/src/features/checker/utils/getGitcoinLinks.ts
@@ -1,5 +1,7 @@
 import { getChains, TChain } from "@gitcoin/gitcoin-chain-data";
 
+import { PoolType } from "@/types";
+
 type ChainIdToType = Record<number, string>;
 
 const chainData = getChains();
@@ -9,23 +11,108 @@ const chainIdToType: ChainIdToType = chainData.reduce((acc, chain: TChain) => {
   return acc;
 }, {} as ChainIdToType);
 
-export const getManagerUrl = (chainId: number): string => {
+const getUrlByChainType = (chainId: number, mainnetUrl: string, stagingUrl: string): string => {
   const chainType = chainIdToType[chainId];
-  return chainType === "mainnet"
-    ? "https://manager.gitcoin.co"
-    : "https://grants-stack-manager-staging.vercel.app";
+  return chainType === "mainnet" ? mainnetUrl : stagingUrl;
 };
 
-export const getBuilderUrl = (chainId: number): string => {
-  const chainType = chainIdToType[chainId];
-  return chainType === "mainnet"
-    ? "https://builder.gitcoin.co"
-    : "https://grants-stack-builder-staging.vercel.app";
+// --- Manager ---
+
+export const getManagerUrl = (chainId: number, strategyName?: PoolType): string => {
+  switch (strategyName) {
+    case PoolType.Retrofunding:
+      return "https://retrofunding-amber.vercel.app";
+    default:
+      return getUrlByChainType(
+        chainId,
+        "https://manager.gitcoin.co",
+        "https://grants-stack-manager-staging.vercel.app",
+      );
+  }
 };
 
-export const getExplorerUrl = (chainId: number): string => {
-  const chainType = chainIdToType[chainId];
-  return chainType === "mainnet"
-    ? "https://explorer.gitcoin.co"
-    : "https://grants-stack-explorer-staging.vercel.app";
+export const getProgramLinkOnManager = (
+  chainId: number,
+  programId: string,
+  strategyName?: PoolType,
+) => {
+  switch (strategyName) {
+    default:
+      return `${getManagerUrl(chainId, strategyName)}/#/chain/${chainId}/program/${programId}`;
+  }
+};
+
+export const getRoundLinkOnManager = (chainId: number, poolId: string, strategyName?: PoolType) => {
+  switch (strategyName) {
+    default:
+      return `${getManagerUrl(chainId, strategyName)}/#/chain/${chainId}/round/${poolId}`;
+  }
+};
+
+// Builder
+
+export const getBuilderUrl = (chainId: number, strategyName?: PoolType): string => {
+  switch (strategyName) {
+    case PoolType.Retrofunding:
+    default:
+      return getUrlByChainType(
+        chainId,
+        "https://builder.gitcoin.co",
+        "https://grants-stack-builder-staging.vercel.app",
+      );
+  }
+};
+
+export const getApplyLink = (chainId: number, poolId: string, strategyName?: PoolType) => {
+  switch (strategyName) {
+    default:
+      return `${getBuilderUrl(chainId, strategyName)}/#/chains/${chainId}/rounds/${poolId}/apply`;
+  }
+};
+
+// --- Explorer ---
+export const getExplorerUrl = (chainId: number, strategyName?: PoolType): string => {
+  switch (strategyName) {
+    case PoolType.Retrofunding:
+      return "https://retrofunding-vote.vercel.app";
+    default:
+      return getUrlByChainType(
+        chainId,
+        "https://explorer.gitcoin.co",
+        "https://grants-stack-explorer-staging.vercel.app",
+      );
+  }
+};
+
+export const getPoolLinkOnExplorer = (chainId: number, poolId: string, strategyName?: PoolType) => {
+  switch (strategyName) {
+    default:
+      return `${getExplorerUrl(chainId, strategyName)}/#/round/${chainId}/${poolId}`;
+  }
+};
+
+export const getApplicationLinkOnExplorer = (
+  chainId: number,
+  poolId: string,
+  applicationId: string,
+  strategyName?: PoolType,
+) => {
+  switch (strategyName) {
+    default:
+      return `${getExplorerUrl(
+        chainId,
+        strategyName,
+      )}/#/round/${chainId}/${poolId}/${applicationId}`;
+  }
+};
+
+export const getVotingInterfaceLinkOnExplorer = (
+  chainId: number,
+  poolId: string,
+  strategyName?: PoolType,
+) => {
+  switch (strategyName) {
+    default:
+      return `${getExplorerUrl(chainId, strategyName)}/#/round/${chainId}/${poolId}/voting`;
+  }
 };

--- a/src/features/pool/components/PoolSummary/PoolSummary.stories.tsx
+++ b/src/features/pool/components/PoolSummary/PoolSummary.stories.tsx
@@ -1,20 +1,24 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { PoolType } from "@/types";
+
 import { PoolSummary, PoolSummaryProps } from "./PoolSummary";
+
+const defaultProps = {
+  chainId: 1,
+  name: "Beta Round",
+  poolId: "1",
+  strategyName: PoolType.QuadraticFunding,
+  applicationsStartTime: "2024-12-09T19:22:56.413Z",
+  applicationsEndTime: "2024-12-10T19:23:30.678Z",
+  donationsStartTime: "2024-12-09T19:22:56.413Z",
+  donationsEndTime: "2024-12-09T19:22:56.413Z",
+};
 
 const meta: Meta<PoolSummaryProps> = {
   title: "Features/Pool/PoolSummary",
   component: PoolSummary,
-  args: {
-    chainId: 1,
-    name: "Beta Round",
-    poolId: "1",
-    strategyName: "allov2.DonationVotingMerkleDistributionDirectTransferStrategy",
-    applicationsStartTime: "2024-12-09T19:22:56.413Z",
-    applicationsEndTime: "2024-12-10T19:23:30.678Z",
-    donationsStartTime: "2024-12-09T19:22:56.413Z",
-    donationsEndTime: "2024-12-09T19:22:56.413Z",
-  },
+  args: defaultProps,
 } satisfies Meta;
 
 export default meta;
@@ -22,3 +26,10 @@ export default meta;
 type Story = StoryObj<typeof PoolSummary>;
 
 export const Default: Story = {};
+
+export const Retrofunding: Story = {
+  args: {
+    ...defaultProps,
+    strategyName: PoolType.Retrofunding,
+  },
+};

--- a/src/features/pool/components/PoolSummary/PoolSummary.tsx
+++ b/src/features/pool/components/PoolSummary/PoolSummary.tsx
@@ -82,10 +82,10 @@ export const PoolSummary = (pool: PoolSummaryProps) => {
     },
   ];
   return (
-    <div className={cn(variants.variants.default, "grid grid-cols-2")}>
+    <div className={cn(variants.variants.default, "grid grid-cols-2 py-6")}>
       <div className="flex flex-col items-start justify-start gap-4">
         <Breadcrumb items={breadcrumbItems} isLoading={pool?.isLoading} />
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-4">
           <div>
             <PoolBadge type="poolType" badge={poolType} isLoading={pool?.isLoading} />
           </div>
@@ -98,12 +98,23 @@ export const PoolSummary = (pool: PoolSummaryProps) => {
             isLoading={pool.isLoading}
             laodingSkeletonClassName="h-10 w-72 rounded-lg"
           />
-          <IconLabel
-            type="roundPeriod"
-            startDate={allocationStartDate}
-            endDate={allocationEndDate}
-            isLoading={pool.isLoading}
-          />
+
+          <div className="flex flex-col gap-2">
+            <IconLabel
+              type="roundPeriod"
+              startDate={registerStartDate}
+              endDate={registerEndDate}
+              isLoading={pool.isLoading}
+              label="Review"
+            />
+            <IconLabel
+              type="roundPeriod"
+              startDate={allocationStartDate}
+              endDate={allocationEndDate}
+              isLoading={pool.isLoading}
+              label="Voting"
+            />
+          </div>
         </div>
       </div>
       <div className="flex flex-col items-end justify-between">

--- a/src/features/pool/components/PoolSummary/PoolSummary.tsx
+++ b/src/features/pool/components/PoolSummary/PoolSummary.tsx
@@ -11,7 +11,13 @@ import { Button } from "@/primitives/Button";
 import { Icon, IconType } from "@/primitives/Icon";
 import { PoolStatus, PoolType } from "@/types";
 
-import { getManagerUrl, getBuilderUrl, getExplorerUrl } from "~checker/utils";
+import {
+  getApplyLink,
+  getPoolLinkOnExplorer,
+  getProgramLinkOnManager,
+  getManagerUrl,
+  getVotingInterfaceLinkOnExplorer,
+} from "~checker/utils";
 
 import { PoolBadge } from "../PoolBadge";
 
@@ -38,12 +44,10 @@ export const PoolSummary = (pool: PoolSummaryProps) => {
   const { toast } = useToast();
   const chainInfo = getChainInfo(pool.chainId);
 
-  const managerUrl = getManagerUrl(pool.chainId);
-  const builderUrl = getBuilderUrl(pool.chainId);
-  const explorerUrl = getExplorerUrl(pool.chainId);
-
   let poolStatus: PoolStatus;
   const poolType = pool.strategyName as PoolType;
+
+  const managerUrl = getManagerUrl(pool.chainId, poolType);
 
   const now = new Date();
 
@@ -67,9 +71,9 @@ export const PoolSummary = (pool: PoolSummaryProps) => {
   } else {
     poolStatus = PoolStatus.PreRound;
   }
-  const applyLink = `${builderUrl}/#/chains/${pool.chainId}/rounds/${pool.poolId}/apply`;
-  const explorerLink = `${explorerUrl}/#/round/${pool.chainId}/${pool.poolId}`;
-  const managerProgramLink = `${managerUrl}/#/chain/${pool.chainId}/program/${pool.programId}`;
+  const applyLink = getApplyLink(pool.chainId, pool.poolId, poolType);
+  const explorerLink = getPoolLinkOnExplorer(pool.chainId, pool.poolId, poolType);
+  const managerProgramLink = getProgramLinkOnManager(pool.chainId, pool.programId, poolType);
   const breadcrumbItems = [
     { label: "My Programs", href: managerUrl },
     {
@@ -81,6 +85,13 @@ export const PoolSummary = (pool: PoolSummaryProps) => {
       href: explorerLink,
     },
   ];
+
+  const { registerDateLabel, allocationDateLabel, viewButton } = getInfoBasedOnPoolType(
+    poolType,
+    pool,
+    explorerLink,
+  );
+
   return (
     <div className={cn(variants.variants.default, "grid grid-cols-2 py-6")}>
       <div className="flex flex-col items-start justify-start gap-4">
@@ -105,14 +116,14 @@ export const PoolSummary = (pool: PoolSummaryProps) => {
               startDate={registerStartDate}
               endDate={registerEndDate}
               isLoading={pool.isLoading}
-              label="Review"
+              label={registerDateLabel}
             />
             <IconLabel
               type="roundPeriod"
               startDate={allocationStartDate}
               endDate={allocationEndDate}
               isLoading={pool.isLoading}
-              label="Voting"
+              label={allocationDateLabel}
             />
           </div>
         </div>
@@ -140,14 +151,45 @@ export const PoolSummary = (pool: PoolSummaryProps) => {
               );
             }}
           />
-          <Button
-            icon={<Icon type={IconType.EXPLORER} />}
-            className="border-grey-100 bg-white text-black shadow-sm"
-            value="View round"
-            onClick={() => window.open(explorerLink, "_blank")}
-          />
+          {viewButton}
         </div>
       </div>
     </div>
   );
 };
+
+function getInfoBasedOnPoolType(poolType: PoolType, pool: PoolSummaryProps, explorerLink: string) {
+  let allocationDateLabel;
+  let registerDateLabel;
+  let viewButton;
+
+  if (poolType === PoolType.Retrofunding) {
+    registerDateLabel = "Applications";
+    allocationDateLabel = "Voting";
+    viewButton = (
+      <Button
+        icon={<Icon type={IconType.LINK} />}
+        className="border-grey-100 bg-white text-black shadow-sm"
+        value="Voting Interface"
+        onClick={() =>
+          window.open(
+            getVotingInterfaceLinkOnExplorer(pool.chainId, pool.poolId, poolType),
+            "_blank",
+          )
+        }
+      />
+    );
+  } else {
+    registerDateLabel = "Review";
+    allocationDateLabel = "Allocation";
+    viewButton = (
+      <Button
+        icon={<Icon type={IconType.EXPLORER} />}
+        className="border-grey-100 bg-white text-black shadow-sm"
+        value="View round"
+        onClick={() => window.open(explorerLink, "_blank")}
+      />
+    );
+  }
+  return { registerDateLabel, allocationDateLabel, viewButton };
+}


### PR DESCRIPTION
- checker: add standalone prop to toggle pool summary
- add ability to have custom manager/explorer/builder link based on pool type
- update pool summary to renders fields based on pool type 

<img width="1211" alt="image" src="https://github.com/user-attachments/assets/b5d983db-a85d-49e8-b40c-512009a6ee8d" />
